### PR TITLE
Read requirements and readme in setup.py as strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@
 from setuptools import setup
 
 
-with open('README.rst', 'rb') as infile:
+with open('README.rst', 'r') as infile:
     long_description = infile.read()
 
-with open('requirements.txt', 'rb') as infile:
+with open('requirements.txt', 'r') as infile:
     install_requires = infile.read().split()
 
 setup(


### PR DESCRIPTION
Should fix [this](https://github.com/habnabit/txsocksx/issues/16) error.